### PR TITLE
Fix developer typo in home layout

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -155,7 +155,7 @@
     "running user research & interviews",
     "developing UX concepts & wireframes",
     "validating hypotheses with real users",
-    "collaborating with stakeholders & devlopers",
+    "collaborating with stakeholders & developers",
     "presenting research insights & design recommendations",
     "building HTML prototypes with contextual user scenarios",
     "testing usability & accessibility against WCAG standards",


### PR DESCRIPTION
## Summary
- fix "devlopers" typo in home layout script

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: bundler: command not found: jekyll)*
- `bundle install` *(fails: 403 "Forbidden" fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6890bb80c414832aaa207643b4c63bab