### PR TITLE
Include markdown files in Tailwind content

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,11 +3,11 @@ module.exports = {
   content: [
     "./_layouts/**/*.html",
     "./_includes/**/*.html", 
-    "./_posts/**/*.{md,markdown}",
-    "./*.{html,markdown}",
-    "./_pages/**/*.{md,markdown}",
-    "./about.markdown",
-    "./index.markdown"
+    "./_posts/**/*.md",
+    "./*.{html,md}",
+    "./_pages/**/*.md",
+    "./about.md",
+    "./index.md"
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
## Summary
- expand Tailwind scan to include Markdown files

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6890bb7cf6a4832ab03ddb55b085a43e