### PR TITLE
fix: include markdown files in tailwind config

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,10 +4,8 @@ module.exports = {
     "./_layouts/**/*.html",
     "./_includes/**/*.html", 
     "./_posts/**/*.{md,markdown}",
-    "./*.{html,markdown}",
+    "./*.{html,md,markdown}",
     "./_pages/**/*.{md,markdown}",
-    "./about.markdown",
-    "./index.markdown"
   ],
   darkMode: 'class',
   theme: {


### PR DESCRIPTION
## Summary
- ensure Tailwind scans markdown pages for classes by including `.md`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build:css`


------
https://chatgpt.com/codex/tasks/task_e_6890b399b8a8832aacb5da98ee137424